### PR TITLE
ci(coverage): replace jest github action reporter w/ codecov

### DIFF
--- a/.github/workflows/example-runs.yml
+++ b/.github/workflows/example-runs.yml
@@ -1,4 +1,4 @@
-name: Example Runs & CI Tests
+name: Example Runs Testing
 
 on:
   push:
@@ -32,14 +32,5 @@ jobs:
         run: echo "The latest release tag is $TAG"
         env:
           TAG: ${{ steps.fetch-latest-github-release.outputs.tag_name }}
-  JestTests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.x'
-      - name: Application Tests
-        run: npm test
+
 

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,7 +1,7 @@
 # This workflow runs the tests for the application and submits coverage report information to CodeCov on every push and Pull Requests that were open.
 # It uses the Action described here https://github.com/marketplace/actions/codecov.
 
-name: Tests Coverage
+name: Jest Tests & Coverage
 on: [push, pull_request]
 jobs:
   coverage:
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout Respository
         uses: actions/checkout@v3
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
             node-version: '16'
       - name: Run the tests # References https://about.codecov.io/blog/measuring-typescript-code-coverage-with-jest-and-github-actions/

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,8 +1,8 @@
-# This workflow runs the tests for the application and comments the coverage report to the pull requests that was open.
-# It uses the Action described here https://github.com/marketplace/actions/jest-annotations-coverage.
+# This workflow runs the tests for the application and submits coverage report information to CodeCov on every push and Pull Requests that were open.
+# It uses the Action described here https://github.com/marketplace/actions/codecov.
 
 name: Tests Coverage
-on: pull_request
+on: [push, pull_request]
 jobs:
   coverage:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -13,7 +13,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
             node-version: '16'
-      - name: Run Jest Test Coverage
-        uses: mattallty/jest-github-action@v1
+      - name: Run the tests # References https://about.codecov.io/blog/measuring-typescript-code-coverage-with-jest-and-github-actions/
+        run: npm test -- --coverage
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 A tiny GitHub action to fetch the latest GitHub Release for a given repository. Originally forked from https://github.com/gregziegan/fetch-latest-release on 2023/04/27.
 
-[![Development Example Test Runs & CI Tests](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml/badge.svg?branch=development)](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml)
-
-[![Production Example Test Runs & CI Tests](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml/badge.svg?branch=production)](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml)
-
-[![codecov](https://codecov.io/gh/CityOfLosAngeles/fetch-latest-github-release/graph/badge.svg?token=TDK6PE2M0T)](https://codecov.io/gh/CityOfLosAngeles/fetch-latest-github-release)
+[![Development Example Test Runs](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml/badge.svg?branch=development)](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml) [![Production Example Test Runs](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml/badge.svg?branch=production)](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml) [![Development Jest Tests & Coverage](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/test-coverage.yml/badge.svg?branch=development)](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/test-coverage.yml) [![Production Jest Tests & Coverage](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/test-coverage.yml/badge.svg?branch=production)](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/test-coverage.yml) [![codecov](https://codecov.io/gh/CityOfLosAngeles/fetch-latest-github-release/graph/badge.svg?token=TDK6PE2M0T)](https://codecov.io/gh/CityOfLosAngeles/fetch-latest-github-release)
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A tiny GitHub action to fetch the latest GitHub Release for a given repository. 
 
 [![Production Example Test Runs & CI Tests](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml/badge.svg?branch=production)](https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/workflows/example-runs.yml)
 
+[![codecov](https://codecov.io/gh/CityOfLosAngeles/fetch-latest-github-release/graph/badge.svg?token=TDK6PE2M0T)](https://codecov.io/gh/CityOfLosAngeles/fetch-latest-github-release)
+
 ## Inputs
 
 | Parameter           | Description                                                                                | Required | Default      |

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,195 @@
+/*
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
 module.exports = {
-    roots: ["<rootDir>/test/"],
-    setupFiles: ["<rootDir>/.jest/setEnvVars.js"]
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/tmp/jest_rs",
+
+  // Automatically clear mock calls, instances, contexts and results before every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  collectCoverage: true,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: undefined,
+
+  // The directory where Jest should output its coverage files
+  coverageDirectory: "coverage",
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // Indicates which provider should be used to instrument code for coverage
+  coverageProvider: "v8",
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: undefined,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: undefined,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // The default configuration for fake timers
+  // fakeTimers: {
+  //   "enableGlobally": false
+  // },
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: undefined,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: undefined,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: undefined,
+
+  // Run tests from one or more projects
+  // projects: undefined,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state before every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: undefined,
+
+  // Automatically restore mock state and implementation before every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: undefined,
+
+  // A list of paths to directories that Jest should use to search for files in
+  roots: [
+    "<rootDir>/test/"
+  ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  setupFiles: ["<rootDir>/.jest/setEnvVars.js"],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: [],
+
+  // The number of seconds after which a test is considered as slow and reported as such in the results.
+  // slowTestThreshold: 5,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  // testEnvironment: "jest-environment-node",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  // testMatch: [
+  //   "**/__tests__/**/*.[jt]s?(x)",
+  //   "**/?(*.)+(spec|test).[tj]s?(x)"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: undefined,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jest-circus/runner",
+
+  // A map from regular expressions to paths to transformers
+  // transform: undefined,
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/",
+  //   "\\.pnp\\.[^\\/]+$"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: undefined,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tiny GitHub action to fetch the latest GitHub Release for a given repository. Originally forked from https://github.com/gregziegan/fetch-latest-release on 2023/04/27",
   "main": "action.js",
   "scripts": {
-    "test": "jest --coverage"
+    "test": "jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What does this PR do?

<!-- Provide information of what the changes in this PR do. This may include both code changes and 
application behavior -->
Replaces the [jest-github-action-reporter](mattallty/jest-github-action@v1) with CodeCov. Integration required the repository to use the [Codecov GitHub Action](https://github.com/marketplace/actions/codecov) in the [test-coverage.yml](https://github.com/CityOfLosAngeles/fetch-latest-github-release/compare/ghi-15?expand=1#diff-10e59ddf73e82826c3d03b454c5235d8e9e810617506db80bced27ee2e1f6c9c) file after the [CodeCov App](https://github.com/apps/codecov) was initialized to the organization. `jest.config.js` was re-initialized with `npx jest --init` to make sure the configuration was what Codecov expected.

Every push to the repository will send a coverage report to CodeCov. Every PR that is open will have Code Coverage information submitted as a comment to the PR.

Jest tests were removed from the example test runs workflow as it is being ran in the test coverage workflow.

### Background info

<!-- Provide relevant information for this PR, such as why it was opened, reasons for the changes, what
needs to noted moving forward, etc. -->
I followed the instructions [here](https://about.codecov.io/blog/measuring-typescript-code-coverage-with-jest-and-github-actions/) to setup CodeCov.

CodeCov status badge was added to the `README.md` following the instructions [here](https://docs.codecov.com/docs/status-badges). Existing badges were modified to better reflect the type of tasks they are performing.

### How can this be tested (manually and/or automated test)?

<!-- Provide steps to manually test the changes if applicable -->
#### Provide Manual tests Steps if applicable

N/A

<!-- Provide steps to run our test tools to test the changes if applicable -->
#### Provide steps for running automated tests if applicable

You can see that the report is uploaded successfully here https://github.com/CityOfLosAngeles/fetch-latest-github-release/actions/runs/5933164934/job/16088184960. You may also check the report uploaded here https://app.codecov.io/gh/CityOfLosAngeles/fetch-latest-github-release/tree/ghi-15.

### Which issue(s) is/are related to this PR?

<!-- List the issues with #<issue-number> -->
This PR is/are related to issue(s) #15 and #8

<!-- List close #<issue-number> for the issues that can be closed by this PR -->
close #15 
close #8 
