### PR TITLE
ci: Potential fix for code scanning alert no. 4; Workflow does not contain permissions

### DIFF
--- a/.github/workflows/example-runs.yml
+++ b/.github/workflows/example-runs.yml
@@ -4,6 +4,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   example:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/CityOfLosAngeles/fetch-latest-github-release/security/code-scanning/4](https://github.com/CityOfLosAngeles/fetch-latest-github-release/security/code-scanning/4)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient for fetching release tags and printing them. If additional permissions are required for specific jobs, they can be defined within the respective job blocks.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. This ensures consistency and reduces the risk of inadvertently granting excessive permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
