### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -2,6 +2,8 @@
 # It uses the Action described here https://github.com/marketplace/actions/codecov.
 
 name: Jest Tests & Coverage
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   coverage:


### PR DESCRIPTION
Potential fix for [https://github.com/CityOfLosAngeles/fetch-latest-github-release/security/code-scanning/2](https://github.com/CityOfLosAngeles/fetch-latest-github-release/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, the workflow primarily reads repository contents and uploads coverage reports to Codecov. Therefore, the `contents: read` permission is sufficient. If additional permissions are required for specific steps, they can be added later.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
